### PR TITLE
Convert a directory of .xml files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 launch.json
 workspace.xml
+*.xml

--- a/convert.py
+++ b/convert.py
@@ -74,10 +74,14 @@ class Convert():
                     'integratedTerminal'
                 )
 
-                if node.getElementsByTagName('module'):
-                    module_name = node.getElementsByTagName('module')[0] \
-                                        .getAttribute('name')
-                    vscode_node.presentation['group'] = module_name
+                if node.getAttribute('folderName') == '':                                   
+                    if node.getElementsByTagName('module'):
+                        module_name = node.getElementsByTagName('module')[0] \
+                                            .getAttribute('name')
+                else:
+                    module_name = node.getAttribute('folderName')
+
+                vscode_node.presentation['group'] = module_name
 
                 node_options = node.getElementsByTagName('option')
                 for option in node_options:


### PR DESCRIPTION
- Now converts all .xml files in directory.
- Converts "Working Directory" into "cwd"
- Eliminates "runtimeExecutable" from launch.json.  Seems that this is not needed anymore in latest VSCode.