### PR TITLE
Add path configuration as command line args

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+f6482b0a26868275bc904511d7730eaf87b24655

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+test*/
+venv/
 launch.json
 workspace.xml
 *.xml
+pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 launch.json
 workspace.xml
+*.xml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now you want to be able to use another IDE such as [VSCode](https://code.visuals
 ## Installation instructions
 
 Download this repository – or at least `convert.py` – to your computer.
-Find your Jetbrains IDE workspace config file (`workspace.xml`) and copy it over.
+Find your Jetbrains IDE workspace config file (`workspace.xml`) and copy it over or copy the absolute path to `workspace.yml`.
 
 **(Optional)** You can drop your [VSCode launch configuration](https://code.visualstudio.com/Docs/editor/debugging) (`launch.json`) over here also. All your existing Run and Debug configurations in VSCode will be replaced with all configurations from your Jetbrains IDE workspace.xml. All other settings are untouched.
 
@@ -22,11 +22,83 @@ Find your Jetbrains IDE workspace config file (`workspace.xml`) and copy it over
 ├── workspace.xml   # Your Jetbrains IDE configuration file.
 ```
 
+`convert.py` takes 2 optional command line arguments: `<source>` and `<destination>`:
+    
+* `<source>`: The absolute or relative path to `workspace.xml`  
+* `<destination>`: The absolute or relative path to `launch.json` (output) or output directory for `launch.json`.
+
+If none of the command line arguments are used, they fallback to `*.xml` and `launch.json`, in current directory. `*.xml` means, that each XML file in the current directory is checked (based on changes from [@dmilkie] (https://github.com/dmilkie)).
+
 ## Usage
+
+### Usage with `workspace.xml` and `launch.json` in the same directory
 
 ```shell
 $ python3 convert.py
 
-> OK written to launch.json.
+Reading from directory <absolute path to current directory>
+> workspace.xml --> found 2 entries
+> launcher manifest.xml --> no configuration
+
+> OK written to launch.json
+> Copy launch.json to your VSCode project / workspace and have fun!
+```
+
+### Usage with `workspace.xml` and `launch.json` in any directory
+
+#### Example 1 - absolute Path with output to `launch.json`
+Define the output path to `launch.json`. The output directory has to exist! It will **NOT** be created from the script.
+
+```shell
+$ python3 convert.py /read/my/project/.idea/workspace.xml /output/to/launch.json
+
+Reading from file /read/my/project/.idea/workspace.xml
+> workspace.xml --> found 2 entries
+
+> OK written to /output/to/launch.json
+> Copy launch.json to your VSCode project / workspace and have fun!
+```
+
+#### Example 2 - absolute Path with output to `launching_launcher.json`
+While defining the path for `launch.json`, you can use any name as the output file.
+
+```shell
+$ python3 convert.py /read/my/project/.idea/workspace.xml /output/to/launching_launcher.json
+
+Reading from file /read/my/project/.idea/workspace.xml
+> workspace.xml --> found 2 entries
+
+> OK written to /output/to/launching_launcher.json
+> Copy launching_launcher.json to your VSCode project / workspace and have fun!
+```
+
+#### Example 3 - absolute Path with output to a path
+You don't have to explicitly write `launch.json` to the output. You can just use the path and file will be automatically set to `launch.json`.
+```shell
+$ python3 convert.py /read/my/project/.idea/workspace.xml /output/to/my/vscode_project
+
+Reading from file /read/my/project/.idea/workspace.xml
+> workspace.xml --> found 2 entries
+
+> OK written to /output/to/my/vscode_project/launch.json
+> Copy launch.json to your VSCode project / workspace and have fun!
+```
+
+#### Example 4 - dynamic resolve of source
+You don't have to provide the absolute path to the `workspace.xml`. It's enough to reference the project directory. The script will automatically append `.idea` and then work on each XML file within the directory.
+```shell
+$ python3 convert.py /read/my/project /output/to/my/vscode_project
+
+Reading from directory /read/my/project/.idea
+> dataSources.local.xml --> no configuration
+> dataSources.xml --> no configuration
+> kubernetes-settings.xml --> no configuration
+> misc.xml --> no configuration
+> modules.xml --> no configuration
+> vcs.xml --> no configuration
+> workspace.xml --> found 2 entries
+> profiles_settings.xml --> no configuration
+
+> OK written to /output/to/my/vscode_project/launch.json
 > Copy launch.json to your VSCode project / workspace and have fun!
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now you want to be able to use another IDE such as [VSCode](https://code.visuals
 ## Installation instructions
 
 Download this repository – or at least `convert.py` – to your computer.
-Find your Jetbrains IDE workspace config file (`workspace.xml`) and copy it over.
+Find your Jetbrains IDE workspace config file (`workspace.xml`) and copy it over or copy the absolute path to `workspace.yml`.
 
 **(Optional)** You can drop your [VSCode launch configuration](https://code.visualstudio.com/Docs/editor/debugging) (`launch.json`) over here also. All your existing Run and Debug configurations in VSCode will be replaced with all configurations from your Jetbrains IDE workspace.xml. All other settings are untouched.
 
@@ -22,11 +22,46 @@ Find your Jetbrains IDE workspace config file (`workspace.xml`) and copy it over
 ├── workspace.xml   # Your Jetbrains IDE configuration file.
 ```
 
+`convert.py` takes 2 optional command line arguments: `<source>` and `<destination>`:
+    
+* `<source>`: The absolute or relative path to `workspace.xml`  
+* `<destination>`: The absolute or relative path to `launch.json` (output) or output directory for `launch.json`.
+
+If none of the command line arguments are used, they fallback to `workspace.xml` and `launch.json`, in current directory.
+
 ## Usage
+
+### Usage with `workspace.xml` and `launch.json` in the same directory
 
 ```shell
 $ python3 convert.py
 
 > OK written to launch.json.
+> Copy launch.json to your VSCode project / workspace and have fun!
+```
+
+### Usage with `workspace.xml` and `launch.json` in any directory
+
+#### Example 1 - absolute Path with output to `launch.json`
+```shell
+$ python3 convert.py /read/my/workspace.xml /output/to/launch.json
+
+> OK written to /output/to/launch.json
+> Copy launch.json to your VSCode project / workspace and have fun!
+```
+
+#### Example 2 - absolute Path with output to `launching_launcher.json`
+```shell
+$ python3 convert.py /read/my/workspace.xml /output/to/launch.json
+
+> OK written to /output/to/launching_launcher.json
+> Copy launching_launcher.json to your VSCode project / workspace and have fun!
+```
+
+#### Example 3 - absolute Path with output to a path
+```shell
+$ python3 convert.py /read/my/workspace.xml /output/to/my/vscode_project
+
+> OK written to /output/to/my/vscode_project/launch.json
 > Copy launch.json to your VSCode project / workspace and have fun!
 ```

--- a/convert.py
+++ b/convert.py
@@ -74,10 +74,14 @@ class Convert():
                     'integratedTerminal'
                 )
 
-                if node.getElementsByTagName('module'):
-                    module_name = node.getElementsByTagName('module')[0] \
-                                        .getAttribute('name')
-                    vscode_node.presentation['group'] = module_name
+                if node.getAttribute('folderName') == '':                                   
+                    if node.getElementsByTagName('module'):
+                        module_name = node.getElementsByTagName('module')[0] \
+                                            .getAttribute('name')
+                else:
+                    module_name = node.getAttribute('folderName')
+
+                vscode_node.presentation['group'] = module_name
 
                 node_options = node.getElementsByTagName('option')
                 for option in node_options:

--- a/convert.py
+++ b/convert.py
@@ -14,34 +14,16 @@
     Warning! But the good news is that is only overwrites the configurations.
     Warning!
 """
-<<<<<<< HEAD
-
-=======
->>>>>>> pr/1
 import sys
 import json
 import xml.dom.minidom
 from pathlib import Path
-<<<<<<< HEAD
-=======
-from os import getcwd
->>>>>>> pr/1
 
 
 __author__ = "github.com/topscoder"
 __license__ = "UNLICENSE"
 
 
-<<<<<<< HEAD
-class Convert():
-    def __init__(self, source: str = "workspace.xml", destination: str = "launch.json"):
-        self.source = Path(source)
-        self.destination = Path(destination)
-        # If only a directory was set as destination, add launch.json as default filename
-        if self.destination.suffix != ".json":
-            self.destination = self.destination / "launch.json"
-        
-=======
 class Convert:
     def __init__(self, source: str = None, destination: str = "launch.json"):
         if source is not None:
@@ -79,18 +61,13 @@ class Convert:
                 )
                 sys.exit(1)
 
->>>>>>> pr/1
         self.now()
 
     def now(self):
         workspace_parsed = self.process_source()
         contents = {}
 
-<<<<<<< HEAD
-        with open(self.destination, 'w+') as target:
-=======
         with open(self.destination, "w+") as target:
->>>>>>> pr/1
             # Warning! It's overwriting all existing configurations.
             try:
                 contents = json.load(target)
@@ -101,15 +78,6 @@ class Convert:
 
             target.close()
 
-<<<<<<< HEAD
-        print(f'> OK written to {self.destination}')
-        print(f'> Copy {self.destination.name} to your VSCode project / workspace '
-              'and have fun!')
-
-    def parse_workspace_xml(self) -> list:
-        doc = xml.dom.minidom.parse(str(self.source))
-        configuration_nodes = doc.getElementsByTagName('configuration')
-=======
         print("")
         print(f"> {bcolors.WHITE}OK written to {bcolors.CYAN}{self.destination}{bcolors.ENDC}")
         print(
@@ -147,7 +115,6 @@ class Convert:
         else:
             print(f" --> no configuration")
 
->>>>>>> pr/1
         nodes = []
         for node in configuration_nodes:
             if node.getAttribute("type") != "PythonConfigurationType":
@@ -262,13 +229,6 @@ class VSCodeConfigurationElement:
             self.__dict__[name] = value.replace("$PROJECT_DIR$", "${workspaceFolder}")
 
 
-<<<<<<< HEAD
-if __name__ == '__main__':    
-    try:
-        Convert(source=sys.argv[1], destination=sys.argv[2])
-    except IndexError:
-        Convert()
-=======
 class bcolors:
     WHITE = "\033[37m"
     PINK = "\033[95m"
@@ -287,4 +247,3 @@ if __name__ == "__main__":
         Convert(source=sys.argv[1], destination=sys.argv[2])
     except IndexError:
         Convert()
->>>>>>> pr/1

--- a/convert.py
+++ b/convert.py
@@ -15,8 +15,10 @@
     Warning!
 """
 
+import sys
 import json
 import xml.dom.minidom
+from pathlib import Path
 
 
 __author__ = "github.com/topscoder"
@@ -24,14 +26,20 @@ __license__ = "UNLICENSE"
 
 
 class Convert():
-    def __init__(self):
+    def __init__(self, source: str = "workspace.xml", destination: str = "launch.json"):
+        self.source = Path(source)
+        self.destination = Path(destination)
+        # If only a directory was set as destination, add launch.json as default filename
+        if self.destination.suffix != ".json":
+            self.destination = self.destination / "launch.json"
+        
         self.now()
 
     def now(self):
         workspace_parsed = self.parse_workspace_xml()
         contents = {}
 
-        with open('launch.json', 'w+') as target:
+        with open(self.destination, 'w+') as target:
             # Warning! It's overwriting all existing configurations.
             try:
                 contents = json.load(target)
@@ -42,12 +50,12 @@ class Convert():
 
             target.close()
 
-        print('> OK written to launch.json.')
-        print('> Copy launch.json to your VSCode project / workspace '
+        print(f'> OK written to {self.destination}')
+        print(f'> Copy {self.destination.name} to your VSCode project / workspace '
               'and have fun!')
 
     def parse_workspace_xml(self) -> list:
-        doc = xml.dom.minidom.parse("workspace.xml")
+        doc = xml.dom.minidom.parse(str(self.source))
         configuration_nodes = doc.getElementsByTagName('configuration')
         nodes = []
 
@@ -160,5 +168,8 @@ class VSCodeConfigurationElement():
                 '${workspaceFolder}')
 
 
-if __name__ == '__main__':
-    Convert()
+if __name__ == '__main__':    
+    try:
+        Convert(source=sys.argv[1], destination=sys.argv[2])
+    except IndexError:
+        Convert()

--- a/convert.py
+++ b/convert.py
@@ -24,7 +24,7 @@ __author__ = "github.com/topscoder"
 __license__ = "UNLICENSE"
 
 
-class Convert():
+class Convert:
     def __init__(self):
         self.now()
 
@@ -32,83 +32,89 @@ class Convert():
         workspace_parsed = self.parse_workspace_xml()
         contents = {}
 
-        with open('launch.json', 'w+') as target:
+        with open("launch.json", "w+") as target:
             # Warning! It's overwriting all existing configurations.
             try:
                 contents = json.load(target)
             except Exception:
                 pass
-            contents['configurations'] = workspace_parsed
+            contents["configurations"] = workspace_parsed
             target.write(json.dumps(contents, indent=2))
 
             target.close()
 
-        print('> OK written to launch.json.')
-        print('> Copy launch.json to your VSCode project / workspace '
-              'and have fun!')
+        print("> OK written to launch.json.")
+        print("> Copy launch.json to your VSCode project / workspace " "and have fun!")
 
     def parse_workspace_xml(self) -> list:
         cwd = Path(getcwd())
         nodes = []
         xml_files = cwd.rglob("*.xml")
         for workspace_xml in cwd.rglob("*.xml"):
-            print(f'> reading {str(workspace_xml)}')
+            print(f"> reading {str(workspace_xml)}")
             doc = xml.dom.minidom.parse(str(workspace_xml))
-            configuration_nodes = doc.getElementsByTagName('configuration')
+            configuration_nodes = doc.getElementsByTagName("configuration")
 
             for node in configuration_nodes:
-                if node.getAttribute('type') != 'PythonConfigurationType':
+                if node.getAttribute("type") != "PythonConfigurationType":
                     continue
 
-                if node.getAttribute('name') == '':
+                if node.getAttribute("name") == "":
                     continue
 
-                if node.getAttribute('type') == '':
+                if node.getAttribute("type") == "":
                     continue
 
                 vscode_node = VSCodeConfigurationElement(
-                    node.getAttribute('name'),
-                    node.getAttribute('type'),
-                    'launch',
-                    '',
-                    'integratedTerminal'
+                    node.getAttribute("name"),
+                    node.getAttribute("type"),
+                    "launch",
+                    "",
+                    "integratedTerminal",
                 )
 
-                if node.getElementsByTagName('module'):
-                    module_name = node.getElementsByTagName('module')[0] \
-                                        .getAttribute('name')
-                    vscode_node.presentation['group'] = module_name
+                if node.getAttribute("folderName") == "":
+                    if node.getElementsByTagName("module"):
+                        module_name = node.getElementsByTagName("module")[0].getAttribute("name")
+                else:
+                    module_name = node.getAttribute("folderName")
 
-                node_options = node.getElementsByTagName('option')
+                vscode_node.presentation["group"] = module_name
+
+                node_options = node.getElementsByTagName("option")
                 for option in node_options:
-                    if option.getAttribute('name') == 'SCRIPT_NAME':
-                        vscode_node.program = option.getAttribute('value')
+                    if option.getAttribute("name") == "SCRIPT_NAME":
+                        vscode_node.program = option.getAttribute("value")
                         continue
 
-                    if option.getAttribute('name') == 'PARAMETERS':
-                        vscode_node.args = option.getAttribute('value').replace('$PROJECT_DIR$','${workspaceFolder}').split(' ')
+                    if option.getAttribute("name") == "PARAMETERS":
+                        vscode_node.args = (
+                            option.getAttribute("value")
+                            .replace("$PROJECT_DIR$", "${workspaceFolder}")
+                            .split(" ")
+                        )
 
-                    if option.getAttribute('name') == 'WORKING_DIRECTORY':
-                        vscode_node.cwd = option.getAttribute('value')
+                    if option.getAttribute("name") == "WORKING_DIRECTORY":
+                        vscode_node.cwd = option.getAttribute("value")
 
                 nodes.append(vscode_node.as_dict())
 
         return nodes
 
 
-class VSCodeConfigurationElement():
+class VSCodeConfigurationElement:
     """This object contains one configuration element.
 
-        Example:
-        {
-            "name": "Python: Current file",
-            "type": "python",
-            "request": "launch",
-            "runtimeExecutable": "python3",
-            "program": "${file}",
-            "console": "integratedTerminal",
-            "args": ["--foobar"]
-        }
+    Example:
+    {
+        "name": "Python: Current file",
+        "type": "python",
+        "request": "launch",
+        "runtimeExecutable": "python3",
+        "program": "${file}",
+        "console": "integratedTerminal",
+        "args": ["--foobar"]
+    }
     """
 
     __name: str
@@ -128,29 +134,26 @@ class VSCodeConfigurationElement():
         self.__request = request
         self.program = program
         self.console = console
-        self.cwd = '${workspaceFolder}'
+        self.cwd = "${workspaceFolder}"
         # self.runtimeExecutable = 'python3'
         self.args = {}
-        self.presentation = {
-            'hidden': False,
-            'group': 'Default'
-        }
+        self.presentation = {"hidden": False, "group": "Default"}
 
-        self.comment = ('Automatically converted from '
-                        'Jetbrains IDE workspace.xml '
-                        'to VSCode launch.json')
+        self.comment = (
+            "Automatically converted from " "Jetbrains IDE workspace.xml " "to VSCode launch.json"
+        )
 
     def as_dict(self):
         return {
-            'type': self.conf_type,
-            'name': self.__name,
-            'request': self.__request,
+            "type": self.conf_type,
+            "name": self.__name,
+            "request": self.__request,
             # 'runtimeExecutable': self.runtimeExecutable,
-            'program': self.program,
-            'console': self.console,
-            'args': self.args,
-            'presentation': self.presentation,
-            'cwd': self.cwd
+            "program": self.program,
+            "console": self.console,
+            "args": self.args,
+            "presentation": self.presentation,
+            "cwd": self.cwd,
         }
 
     def as_json(self):
@@ -158,17 +161,12 @@ class VSCodeConfigurationElement():
 
     def __setattr__(self, name, value):
         self.__dict__[name] = value
-        if name == 'conf_type':
-            self.__dict__[name] = value.replace(
-                'PythonConfigurationType',
-                'python'
-            )
+        if name == "conf_type":
+            self.__dict__[name] = value.replace("PythonConfigurationType", "python")
 
-        if '$PROJECT_DIR$' in value:
-            self.__dict__[name] = value.replace(
-                '$PROJECT_DIR$',
-                '${workspaceFolder}')
+        if "$PROJECT_DIR$" in value:
+            self.__dict__[name] = value.replace("$PROJECT_DIR$", "${workspaceFolder}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     Convert()

--- a/convert.py
+++ b/convert.py
@@ -14,10 +14,11 @@
     Warning! But the good news is that is only overwrites the configurations.
     Warning!
 """
-from pathlib import Path
-from os import getcwd
+import sys
 import json
 import xml.dom.minidom
+from pathlib import Path
+from os import getcwd
 
 
 __author__ = "github.com/topscoder"
@@ -25,14 +26,49 @@ __license__ = "UNLICENSE"
 
 
 class Convert:
-    def __init__(self):
+    def __init__(self, source: str = None, destination: str = "launch.json"):
+        if source is not None:
+            self.source = Path(source)
+
+            if self.source.suffix != ".xml":
+                # source is not an XML file
+                if self.source.name != ".idea" and self.source.is_dir():
+                    # source is not the .idea directory
+                    # now we assume, that we are in the base directory of the project and append .idea
+                    print(f"{bcolors.WARNING}Auto-adding '.idea' to path")
+                    self.source = self.source / ".idea"
+
+            if self.source.exists() is not True:
+                print(
+                    f"{bcolors.FAIL}"
+                    f"Source {self.source} doesn't exist or is not accessible!"
+                    f"{bcolors.ENDC}"
+                )
+                sys.exit(1)
+
+        else:
+            self.source = Path()
+
+        self.destination = Path(destination)
+        # If only a directory was set as destination, add launch.json as default filename
+        if self.destination.suffix != ".json":
+            if self.destination.is_dir():
+                self.destination = self.destination / "launch.json"
+            else:
+                print(
+                    f"{bcolors.FAIL}"
+                    f"Destination {self.destination} doesn't exist or is not accessible!"
+                    f"{bcolors.ENDC}"
+                )
+                sys.exit(1)
+
         self.now()
 
     def now(self):
-        workspace_parsed = self.parse_workspace_xml()
+        workspace_parsed = self.process_source()
         contents = {}
 
-        with open("launch.json", "w+") as target:
+        with open(self.destination, "w+") as target:
             # Warning! It's overwriting all existing configurations.
             try:
                 contents = json.load(target)
@@ -43,61 +79,87 @@ class Convert:
 
             target.close()
 
-        print("> OK written to launch.json.")
-        print("> Copy launch.json to your VSCode project / workspace " "and have fun!")
+        print("")
+        print(f"> {bcolors.WHITE}OK written to {bcolors.CYAN}{self.destination}{bcolors.ENDC}")
+        print(
+            f"> {bcolors.WHITE}Copy {bcolors.CYAN}{self.destination.name}{bcolors.WHITE} "
+            f"to your VSCode project / workspace and have fun!{bcolors.ENDC}"
+        )
 
-    def parse_workspace_xml(self) -> list:
-        cwd = Path(getcwd())
+    def process_source(self):
+        nodes_configuration = []
+
+        if self.source.suffix == ".xml":
+            print(
+                f"{bcolors.WHITE}Reading from {bcolors.BOLD}file{bcolors.ENDC} {bcolors.WHITE}{self.source.absolute()}{bcolors.ENDC}"
+            )
+            nodes = self.parse_workspace_xml(self.source)
+            if nodes:
+                nodes_configuration.append(nodes)
+        else:
+            print(
+                f"{bcolors.WHITE}Reading from {bcolors.BOLD}directory{bcolors.ENDC} {bcolors.WHITE}{self.source.absolute()}{bcolors.ENDC}"
+            )
+            for workspace_xml in self.source.rglob("*.xml"):
+                nodes = self.parse_workspace_xml(workspace_xml)
+                if nodes:
+                    nodes_configuration.append(nodes)
+
+        return nodes_configuration
+
+    def parse_workspace_xml(self, filename: str):
+        print(f"> {filename.name}", end="")
+        doc = xml.dom.minidom.parse(str(filename))
+        configuration_nodes = doc.getElementsByTagName("configuration")
+        if len(configuration_nodes) > 0:
+            print(f" --> {bcolors.GREEN}found {len(configuration_nodes)} entries{bcolors.ENDC}")
+        else:
+            print(f" --> no configuration")
+
         nodes = []
-        xml_files = cwd.rglob("*.xml")
-        for workspace_xml in cwd.rglob("*.xml"):
-            print(f"> reading {str(workspace_xml)}")
-            doc = xml.dom.minidom.parse(str(workspace_xml))
-            configuration_nodes = doc.getElementsByTagName("configuration")
+        for node in configuration_nodes:
+            if node.getAttribute("type") != "PythonConfigurationType":
+                continue
 
-            for node in configuration_nodes:
-                if node.getAttribute("type") != "PythonConfigurationType":
+            if node.getAttribute("name") == "":
+                continue
+
+            if node.getAttribute("type") == "":
+                continue
+
+            vscode_node = VSCodeConfigurationElement(
+                node.getAttribute("name"),
+                node.getAttribute("type"),
+                "launch",
+                "",
+                "integratedTerminal",
+            )
+
+            if node.getAttribute("folderName") == "":
+                if node.getElementsByTagName("module"):
+                    module_name = node.getElementsByTagName("module")[0].getAttribute("name")
+            else:
+                module_name = node.getAttribute("folderName")
+
+            vscode_node.presentation["group"] = module_name
+
+            node_options = node.getElementsByTagName("option")
+            for option in node_options:
+                if option.getAttribute("name") == "SCRIPT_NAME":
+                    vscode_node.program = option.getAttribute("value")
                     continue
 
-                if node.getAttribute("name") == "":
-                    continue
+                if option.getAttribute("name") == "PARAMETERS":
+                    vscode_node.args = (
+                        option.getAttribute("value")
+                        .replace("$PROJECT_DIR$", "${workspaceFolder}")
+                        .split(" ")
+                    )
 
-                if node.getAttribute("type") == "":
-                    continue
+                if option.getAttribute("name") == "WORKING_DIRECTORY":
+                    vscode_node.cwd = option.getAttribute("value")
 
-                vscode_node = VSCodeConfigurationElement(
-                    node.getAttribute("name"),
-                    node.getAttribute("type"),
-                    "launch",
-                    "",
-                    "integratedTerminal",
-                )
-
-                if node.getAttribute("folderName") == "":
-                    if node.getElementsByTagName("module"):
-                        module_name = node.getElementsByTagName("module")[0].getAttribute("name")
-                else:
-                    module_name = node.getAttribute("folderName")
-
-                vscode_node.presentation["group"] = module_name
-
-                node_options = node.getElementsByTagName("option")
-                for option in node_options:
-                    if option.getAttribute("name") == "SCRIPT_NAME":
-                        vscode_node.program = option.getAttribute("value")
-                        continue
-
-                    if option.getAttribute("name") == "PARAMETERS":
-                        vscode_node.args = (
-                            option.getAttribute("value")
-                            .replace("$PROJECT_DIR$", "${workspaceFolder}")
-                            .split(" ")
-                        )
-
-                    if option.getAttribute("name") == "WORKING_DIRECTORY":
-                        vscode_node.cwd = option.getAttribute("value")
-
-                nodes.append(vscode_node.as_dict())
+            nodes.append(vscode_node.as_dict())
 
         return nodes
 
@@ -168,5 +230,21 @@ class VSCodeConfigurationElement:
             self.__dict__[name] = value.replace("$PROJECT_DIR$", "${workspaceFolder}")
 
 
+class bcolors:
+    WHITE = "\033[37m"
+    PINK = "\033[95m"
+    BLUE = "\033[94m"
+    CYAN = "\033[96m"
+    GREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
 if __name__ == "__main__":
-    Convert()
+    try:
+        Convert(source=sys.argv[1], destination=sys.argv[2])
+    except IndexError:
+        Convert()


### PR DESCRIPTION
Instead of only considering files in the current directory, you can add `<source>` and `<destination>` to the command line, which will be used for reading from anywhere and outputing the `launch.json` to anywhere.

My thought on this change was, that I want to convert the `workspace.xml` from my source directories, directly to the new directory, without the need to copy them upfront.